### PR TITLE
align method name casing to be all snake_case

### DIFF
--- a/path-planning/include/path-planning/point.hpp
+++ b/path-planning/include/path-planning/point.hpp
@@ -10,8 +10,8 @@ namespace pathplanning::geometry {
 
         double euclidian_distance(const Point& other) const;
 
-        double getX() const;
-        double getY() const;
+        double get_x() const;
+        double get_y() const;
     private:
         double x;
         double y;

--- a/path-planning/include/path-planning/zone.hpp
+++ b/path-planning/include/path-planning/zone.hpp
@@ -10,10 +10,10 @@ namespace pathplanning::geometry {
     public:
         RectangularZone(const Point& point, const Point& opposite);
 
-        double getLeftLine() const;
-        double getRightLine() const;
-        double getTopLine() const;
-        double getBottomLine() const;
+        double get_left_line() const;
+        double get_right_line() const;
+        double get_top_line() const;
+        double get_bottom_line() const;
 
     private:
         Point point;

--- a/path-planning/src/obstacle_rectangle.cpp
+++ b/path-planning/src/obstacle_rectangle.cpp
@@ -7,7 +7,7 @@ namespace pathplanning::map {
         point(point), opposite(opposite) {}
 
     SurfaceRelationship RectangleObstacle::contains(const geometry::RectangularZone& zone) const {
-        if (containsFully(zone)) {
+        if (contains_fully(zone)) {
             return SurfaceRelationship::CONTAINS;
         } else if (overlap(zone)) {
             return SurfaceRelationship::OVERLAP;
@@ -15,39 +15,39 @@ namespace pathplanning::map {
         return SurfaceRelationship::DISJOINT;
     }
 
-    bool RectangleObstacle::containsFully(const geometry::RectangularZone& zone) const {
-        if (getLeftLine() < zone.getLeftLine() && getRightLine() > zone.getRightLine() &&
-                getBottomLine() < zone.getBottomLine() && getTopLine() > zone.getTopLine()) {
+    bool RectangleObstacle::contains_fully(const geometry::RectangularZone& zone) const {
+        if (get_left_line() < zone.get_left_line() && get_right_line() > zone.get_right_line() &&
+                get_bottom_line() < zone.get_bottom_line() && get_top_line() > zone.get_top_line()) {
             return true;
         }
         return false;
     }
 
     bool RectangleObstacle::overlap(const geometry::RectangularZone& zone) const {
-        if (getRightLine() < zone.getLeftLine() || getLeftLine() > zone.getRightLine()) {
+        if (get_right_line() < zone.get_left_line() || get_left_line() > zone.get_right_line()) {
             // If x coordinates don't cross, it's impossible to have an overlap
             return false;
         }
-        if (getTopLine() < zone.getBottomLine() || getBottomLine() > zone.getTopLine()) {
+        if (get_top_line() < zone.get_bottom_line() || get_bottom_line() > zone.get_top_line()) {
             // If y coordinates don't cross, it's impossible to have an overlap
             return false;
         }
         return true;
     }
 
-    double RectangleObstacle::getLeftLine() const {
-        return std::min(point.getX(), opposite.getX());
+    double RectangleObstacle::get_left_line() const {
+        return std::min(point.get_x(), opposite.get_x());
     }
 
-    double RectangleObstacle::getRightLine() const {
-        return std::max(point.getX(), opposite.getX());
+    double RectangleObstacle::get_right_line() const {
+        return std::max(point.get_x(), opposite.get_x());
     }
 
-    double RectangleObstacle::getBottomLine() const {
-        return std::min(point.getY(), opposite.getY());
+    double RectangleObstacle::get_bottom_line() const {
+        return std::min(point.get_y(), opposite.get_y());
     }
 
-    double RectangleObstacle::getTopLine() const {
-        return std::max(point.getY(), opposite.getY());
+    double RectangleObstacle::get_top_line() const {
+        return std::max(point.get_y(), opposite.get_y());
     }
 }

--- a/path-planning/src/obstacle_rectangle.hpp
+++ b/path-planning/src/obstacle_rectangle.hpp
@@ -11,13 +11,13 @@ namespace pathplanning::map {
         SurfaceRelationship contains(const geometry::RectangularZone& area) const override;
 
     private:
-        bool containsFully(const geometry::RectangularZone& area) const;
+        bool contains_fully(const geometry::RectangularZone& area) const;
         bool overlap(const geometry::RectangularZone& area) const;
 
-        double getLeftLine() const;
-        double getRightLine() const;
-        double getTopLine() const;
-        double getBottomLine() const;
+        double get_left_line() const;
+        double get_right_line() const;
+        double get_top_line() const;
+        double get_bottom_line() const;
 
         const geometry::Point point;
         const geometry::Point opposite;

--- a/path-planning/src/point.cpp
+++ b/path-planning/src/point.cpp
@@ -16,11 +16,11 @@ namespace pathplanning::geometry {
         return std::sqrt(std::pow(x - other.x, 2) + std::pow(y - other.y, 2));
     }
 
-    double Point::getX() const {
+    double Point::get_x() const {
         return x;
     }
 
-    double Point::getY() const {
+    double Point::get_y() const {
         return y;
     }
 

--- a/path-planning/src/rectangular_zone.cpp
+++ b/path-planning/src/rectangular_zone.cpp
@@ -7,20 +7,20 @@ namespace pathplanning::geometry {
     RectangularZone::RectangularZone(const Point& point, const Point& opposite):
         point(point), opposite(opposite) {}
 
-    double RectangularZone::getLeftLine() const {
-        return std::min(point.getX(), opposite.getX());
+    double RectangularZone::get_left_line() const {
+        return std::min(point.get_x(), opposite.get_x());
     }
 
-    double RectangularZone::getRightLine() const {
-        return std::max(point.getX(), opposite.getX());
+    double RectangularZone::get_right_line() const {
+        return std::max(point.get_x(), opposite.get_x());
     }
 
-    double RectangularZone::getBottomLine() const {
-        return std::min(point.getY(), opposite.getY());
+    double RectangularZone::get_bottom_line() const {
+        return std::min(point.get_y(), opposite.get_y());
     }
 
-    double RectangularZone::getTopLine() const {
-        return std::max(point.getY(), opposite.getY());
+    double RectangularZone::get_top_line() const {
+        return std::max(point.get_y(), opposite.get_y());
     }
 
 }


### PR DESCRIPTION
I don't know why but at one point, I started using CamelCase instead of snake_case. The main reason to use snake_case is that the standard library is using snake_case. 

Sorry @JonathanPetit but I believe this should be merged before #6 and you should afterwards update your PR to avoid any build breakage :/ 