### PR TITLE
move distance computing to low level sensor

### DIFF
--- a/io-interface/include/io-interface/ultra_sonic_sensor.hpp
+++ b/io-interface/include/io-interface/ultra_sonic_sensor.hpp
@@ -5,6 +5,7 @@ namespace iointerface::sensor {
     class UltraSonicSensor {
     public:
         UltraSonicSensor();
+        double get_distance() const;
     };
 
 }

--- a/io-interface/src/raspi/ultra_sonic_sensor.cpp
+++ b/io-interface/src/raspi/ultra_sonic_sensor.cpp
@@ -4,4 +4,7 @@ namespace iointerface::sensor {
 
     UltraSonicSensor::UltraSonicSensor() {}
 
+    double UltraSonicSensor::get_distance() const {
+        return 10; // should come from the sensor itself
+    }
 }

--- a/robotlib/CMakeLists.txt
+++ b/robotlib/CMakeLists.txt
@@ -1,1 +1,5 @@
 add_subdirectory(src)
+
+if(BUILD_TESTING) 
+    add_subdirectory(tests)
+endif()

--- a/robotlib/include/robotlib/proximity_handler.hpp
+++ b/robotlib/include/robotlib/proximity_handler.hpp
@@ -2,15 +2,18 @@
 
 #include <io-interface/ultra_sonic_sensor.hpp>
 
+using namespace iointerface::sensor;
+
 namespace robotlib::proximity_handler {
 
     class ProximityHandler {
     public: 
-        ProximityHandler(const double min_distance);
+        ProximityHandler(UltraSonicSensor us_sensor, const double min_distance);
         bool is_too_close() const;
 
     private: 
         double min_distance;
+        UltraSonicSensor us_sensor;
     };
 
 }

--- a/robotlib/include/robotlib/proximity_handler.hpp
+++ b/robotlib/include/robotlib/proximity_handler.hpp
@@ -2,18 +2,18 @@
 
 #include <io-interface/ultra_sonic_sensor.hpp>
 
-using namespace iointerface::sensor;
-
 namespace robotlib::proximity_handler {
+
+    using namespace iointerface::sensor;
 
     class ProximityHandler {
     public: 
-        ProximityHandler(UltraSonicSensor us_sensor, const double min_distance);
+        ProximityHandler(const UltraSonicSensor& us_sensor, const double min_distance);
         bool is_too_close() const;
 
     private: 
-        double min_distance;
-        UltraSonicSensor us_sensor;
+        const double min_distance;
+        const UltraSonicSensor us_sensor;
     };
 
 }

--- a/robotlib/src/CMakeLists.txt
+++ b/robotlib/src/CMakeLists.txt
@@ -8,7 +8,6 @@ target_link_libraries(robotlib
 target_include_directories(robotlib 
     PUBLIC ../include 
     PRIVATE .
-    PRIVATE ../../io-interface/include/
 )
 
 target_compile_features(robotlib PUBLIC cxx_std_17)

--- a/robotlib/src/proximity_handler.cpp
+++ b/robotlib/src/proximity_handler.cpp
@@ -2,11 +2,11 @@
 
 namespace robotlib::proximity_handler {
 
-    ProximityHandler::ProximityHandler(const double min_distance):
-        min_distance(min_distance) {}
+    ProximityHandler::ProximityHandler(UltraSonicSensor us_sensor, const double min_distance):
+        us_sensor(us_sensor), min_distance(min_distance) {}
 
     bool ProximityHandler::is_too_close() const {
-        double distance = 10; // should be returned by the actual sensor
+        const double distance = us_sensor.get_distance();
 
         if (distance > min_distance) {
             return true;

--- a/robotlib/src/proximity_handler.cpp
+++ b/robotlib/src/proximity_handler.cpp
@@ -2,7 +2,7 @@
 
 namespace robotlib::proximity_handler {
 
-    ProximityHandler::ProximityHandler(UltraSonicSensor us_sensor, const double min_distance):
+    ProximityHandler::ProximityHandler(const UltraSonicSensor& us_sensor, const double min_distance):
         us_sensor(us_sensor), min_distance(min_distance) {}
 
     bool ProximityHandler::is_too_close() const {

--- a/robotlib/tests/CMakeLists.txt
+++ b/robotlib/tests/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_executable("robotlib-test"
+    test-proximity-detection.cpp
+    main.cpp)
+
+target_link_libraries("robotlib-test"
+    PRIVATE "robotlib" "io-interface-raspi" Catch2::Catch2)
+
+target_compile_features("robotlib-test" PRIVATE cxx_std_17)
+
+add_test(NAME Robotlib COMMAND "robotlib-test")

--- a/robotlib/tests/main.cpp
+++ b/robotlib/tests/main.cpp
@@ -1,0 +1,3 @@
+#define CATCH_CONFIG_MAIN 
+
+#include "catch2/catch.hpp"

--- a/robotlib/tests/test-proximity-detection.cpp
+++ b/robotlib/tests/test-proximity-detection.cpp
@@ -2,11 +2,15 @@
 
 #include <robotlib/proximity_handler.hpp>
 
+using namespace iointerface::sensor;
 using namespace robotlib::proximity_handler;
 
 TEST_CASE("Verify the proximity handler detects to close objects") {
+    const double min_distance = 20;
+    UltraSonicSensor us_sensor;
+    ProximityHandler proximity_handler(us_sensor, min_distance);
 
-    SECTION("to close object") {
-        REQUIRE(1 == 1);
+    SECTION("far enough from any object") {
+        REQUIRE(false == proximity_handler.is_too_close());
     }
 }

--- a/robotlib/tests/test-proximity-detection.cpp
+++ b/robotlib/tests/test-proximity-detection.cpp
@@ -1,0 +1,12 @@
+#include <catch2/catch.hpp>
+
+#include <robotlib/proximity_handler.hpp>
+
+using namespace robotlib::proximity_handler;
+
+TEST_CASE("Verify the proximity handler detects to close objects") {
+
+    SECTION("to close object") {
+        REQUIRE(1 == 1);
+    }
+}


### PR DESCRIPTION
Creating some more structure. The idea to move distance computing to lower classes is to easily mock those classes during tests.