### PR TITLE
Add clang-tidy support

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,20 @@
+---
+Checks: >
+  clang-diagnostic-*,
+  clang-analyzer-*,
+  bugprone-*,
+  cppcoreguidelines-*,
+  misc-*,
+  modernize-*,
+  performance-*,
+  readabilitiy-*,
+  -modernize-use-nodiscard
+WarningsAsErrors: ''
+HeaderFilterRegex: '.'
+AnalyzeTemporaryDtors: false
+FormatStyle: none
+CheckOptions:
+  - key: cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor
+    value: '1'
+...
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,16 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(Catch2)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-set(CMAKE_CXX_CLANG_TIDY "clang-tidy")
+
+message(STATUS "Looking for clang-tidy")
+find_program(CLANG_TIDY NAMES clang-tidy)
+
+if (CLANG_TIDY)
+    message(STATUS "Looking for clang-tidy - found ${CLANG_TIDY}")
+    set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY}")
+else()
+    message(STATUS "Looking for clang-tidy - not found")
+endif()
 
 add_subdirectory("path-planning")
 add_subdirectory("robotlib")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,9 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(Catch2)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+set(CMAKE_CXX_CLANG_TIDY "clang-tidy")
+
 add_subdirectory("path-planning")
 add_subdirectory("robotlib")
 add_subdirectory("io-interface")

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -1,0 +1,16 @@
+# Tooling
+
+## clang-tidy
+
+### Fixing common issues automatically
+
+At the root of the project, you can run:
+
+```
+clang-tidy -p ${BUILD_FOLDER}/compile_commands.json -header-filter=. -fix ${CPP_FILES}
+```
+
+where the variables are:
+
+- `BUILDER_FOLDER`: the cmake build folder
+- `CPP_FILES`: the cpp files you want to fix

--- a/io-interface/include/io-interface/ultra_sonic_sensor.hpp
+++ b/io-interface/include/io-interface/ultra_sonic_sensor.hpp
@@ -5,7 +5,7 @@ namespace iointerface::sensor {
     class UltraSonicSensor {
     public:
         UltraSonicSensor();
-        double get_distance() const;
+        auto get_distance() const -> double;
     };
 
 }

--- a/io-interface/src/raspi/ultra_sonic_sensor.cpp
+++ b/io-interface/src/raspi/ultra_sonic_sensor.cpp
@@ -2,9 +2,9 @@
 
 namespace iointerface::sensor {
 
-    UltraSonicSensor::UltraSonicSensor() {}
+    UltraSonicSensor::UltraSonicSensor() = default;
 
-    double UltraSonicSensor::get_distance() const {
+    auto UltraSonicSensor::get_distance() const -> double {
         return 10; // should come from the sensor itself
     }
 }

--- a/path-planning/include/path-planning/map.hpp
+++ b/path-planning/include/path-planning/map.hpp
@@ -16,9 +16,9 @@ namespace pathplanning::map {
 
         void set_precision(double precision);
 
-        double get_length() const;
-        double get_width() const;
-        double get_precision() const;
+        auto get_length() const -> double;
+        auto get_width() const -> double;
+        auto get_precision() const -> double;
 
     private:
         double length;
@@ -28,11 +28,11 @@ namespace pathplanning::map {
 
     class Map {
     public:
-        virtual ~Map();
+        virtual ~Map() = default;
 
-        static std::unique_ptr<Map> make(const MapDimension& dimension, const std::vector<std::shared_ptr<Obstacle>>& obstacles);
+        static auto make(const MapDimension& dimension, const std::vector<std::shared_ptr<Obstacle>>& obstacles) -> std::unique_ptr<Map>;
 
-        virtual bool is_point_in_obstacle(const geometry::Point& point) const = 0;
+        virtual auto is_point_in_obstacle(const geometry::Point& point) const -> bool = 0;
     };
 
 }

--- a/path-planning/include/path-planning/obstacle.hpp
+++ b/path-planning/include/path-planning/obstacle.hpp
@@ -16,10 +16,10 @@ namespace pathplanning::map {
 
     class Obstacle {
     public:
-        static std::unique_ptr<Obstacle> make_rectangle(const geometry::Point& point, const geometry::Point& opposite);
-        static std::unique_ptr<Obstacle> make_circle(const geometry::Point& center, double radius);
+        static auto make_rectangle(const geometry::Point& point, const geometry::Point& opposite) -> std::unique_ptr<Obstacle>;
+        static auto make_circle(const geometry::Point& center, double radius) -> std::unique_ptr<Obstacle>;
 
-        virtual ~Obstacle();
+        virtual ~Obstacle() = default;
 
         // Check the obstacle relationship with a given zone
         //  - OVERLAP: the obstacle overlap with the given zone
@@ -28,7 +28,7 @@ namespace pathplanning::map {
         //  - CONTAINED: the obstacle is contained in the zone
         // If the obstacle is touching the zone only by a point or a line, the obstacle 
         //  is considered DISJOINT from the zone.
-        virtual SurfaceRelationship get_relation_with_zone(const geometry::StraightRectangle& rectangle) const = 0;
+        virtual auto get_relation_with_zone(const geometry::StraightRectangle& rectangle) const -> SurfaceRelationship = 0;
     };
 
 }

--- a/path-planning/include/path-planning/point.hpp
+++ b/path-planning/include/path-planning/point.hpp
@@ -6,12 +6,12 @@ namespace pathplanning::geometry {
     public:
         Point(double x, double y);
 
-        bool operator==(const Point& other) const;
+        auto operator==(const Point& other) const -> bool;
 
-        double euclidian_distance(const Point& other) const;
+        auto euclidian_distance(const Point& other) const -> double;
 
-        double get_x() const;
-        double get_y() const;
+        auto get_x() const -> double;
+        auto get_y() const -> double;
     private:
         double x;
         double y;

--- a/path-planning/include/path-planning/shape.hpp
+++ b/path-planning/include/path-planning/shape.hpp
@@ -10,22 +10,22 @@ namespace pathplanning::geometry {
     public:
         StraightRectangle(const Point& corner, const Point& opposite_corner);
 
-        double get_left_line() const;
-        double get_right_line() const;
-        double get_top_line() const;
-        double get_bottom_line() const;
+        auto get_left_line() const -> double;
+        auto get_right_line() const -> double;
+        auto get_top_line() const -> double;
+        auto get_bottom_line() const -> double;
 
-        Point get_top_left_corner() const;
-        Point get_top_right_corner() const;
-        Point get_bottom_left_corner() const;
-        Point get_bottom_right_corner() const;
+        auto get_top_left_corner() const -> Point;
+        auto get_top_right_corner() const -> Point;
+        auto get_bottom_left_corner() const -> Point;
+        auto get_bottom_right_corner() const -> Point;
 
-        double get_width() const;
-        double get_height() const;
+        auto get_width() const -> double;
+        auto get_height() const -> double;
         
-        Point get_center() const;
+        auto get_center() const -> Point;
 
-        double get_area() const;
+        auto get_area() const -> double;
 
     private:
         Point bottom_left_corner;

--- a/path-planning/src/map.cpp
+++ b/path-planning/src/map.cpp
@@ -5,9 +5,7 @@
 
 namespace pathplanning::map {
 
-    Map::~Map() {}
-
-    std::unique_ptr<Map> Map::make(const MapDimension& dimension, const std::vector<std::shared_ptr<Obstacle>>& obstacles) {
+    auto Map::make(const MapDimension& dimension, const std::vector<std::shared_ptr<Obstacle>>& obstacles) -> std::unique_ptr<Map> {
         return std::make_unique<MapImpl>(dimension, obstacles);
     }
 
@@ -18,15 +16,15 @@ namespace pathplanning::map {
         this->precision = precision;
     }
 
-    double MapDimension::get_length() const {
+    auto MapDimension::get_length() const -> double {
         return length;
     }
 
-    double MapDimension::get_width() const {
+    auto MapDimension::get_width() const -> double {
         return width;
     }
 
-    double MapDimension::get_precision() const {
+    auto MapDimension::get_precision() const -> double {
         return precision;
     }
 }

--- a/path-planning/src/map_impl.hpp
+++ b/path-planning/src/map_impl.hpp
@@ -15,17 +15,17 @@ namespace pathplanning::map {
     public:
         MapImpl(const MapDimension& dimension, const std::vector<std::shared_ptr<Obstacle>>& obstacles);
 
-        bool is_point_in_obstacle(const geometry::Point& point) const override;
+        auto is_point_in_obstacle(const geometry::Point& point) const -> bool override;
 
     private:
-        bool is_point_in_map(const geometry::Point& point) const;
-        bool is_point_in_obstacle_recursive(const quadtree::Node<ZoneStatus>& node, const geometry::Point& point) const;
+        auto is_point_in_map(const geometry::Point& point) const -> bool;
+        auto is_point_in_obstacle_recursive(const quadtree::Node<ZoneStatus>& node, const geometry::Point& point) const -> bool;
 
-        static quadtree::Root<ZoneStatus> build_map(const MapDimension& dimension, const std::vector<std::shared_ptr<Obstacle>>& obstacles);
-        static void add_obstacle_to_map(quadtree::Root<ZoneStatus>& root, std::shared_ptr<Obstacle> obstacle, double precision);
-        static void obstacle_refinement(quadtree::Node<ZoneStatus>& node, std::shared_ptr<Obstacle> obstacle, double precision);
-        static void base_case_obstacle_refinement(quadtree::Node<ZoneStatus>& node, std::shared_ptr<Obstacle> obstacle);
-        static void recursive_case_obstacle_refinement(quadtree::Node<ZoneStatus>& node, std::shared_ptr<Obstacle> obstacle, double precision);
+        static auto build_map(const MapDimension& dimension, const std::vector<std::shared_ptr<Obstacle>>& obstacles) -> quadtree::Root<ZoneStatus>;
+        static void add_obstacle_to_map(quadtree::Root<ZoneStatus>& root, const std::shared_ptr<Obstacle>& obstacle, double precision);
+        static void obstacle_refinement(quadtree::Node<ZoneStatus>& node, const std::shared_ptr<Obstacle>& obstacle, double precision);
+        static void base_case_obstacle_refinement(quadtree::Node<ZoneStatus>& node, const std::shared_ptr<Obstacle>& obstacle);
+        static void recursive_case_obstacle_refinement(quadtree::Node<ZoneStatus>& node, const std::shared_ptr<Obstacle>& obstacle, double precision);
 
         quadtree::Root<ZoneStatus> map;
     };

--- a/path-planning/src/math_utils.hpp
+++ b/path-planning/src/math_utils.hpp
@@ -8,8 +8,8 @@ namespace pathplanning::math {
     // Check whether two floating points numbers are almost equals
     // Taken from https://en.cppreference.com/w/cpp/types/numeric_limits/epsilon
     template<class T>
-    typename std::enable_if<!std::numeric_limits<T>::is_integer, bool>::type
-        almost_equal(T x, T y, int ulp = 5)
+    auto
+        almost_equal(T x, T y, int ulp = 5) -> typename std::enable_if<!std::numeric_limits<T>::is_integer, bool>::type
     {
         // the machine epsilon has to be scaled to the magnitude of the values used
         // and multiplied by the desired precision in ULPs (units in the last place)

--- a/path-planning/src/obstacle.cpp
+++ b/path-planning/src/obstacle.cpp
@@ -4,14 +4,12 @@
 
 namespace pathplanning::map {
 
-    std::unique_ptr<Obstacle> Obstacle::make_rectangle(const geometry::Point& point, const geometry::Point& opposite) {
+    auto Obstacle::make_rectangle(const geometry::Point& point, const geometry::Point& opposite) -> std::unique_ptr<Obstacle> {
         return std::make_unique<RectangleObstacle>(point, opposite);
     }
 
-    std::unique_ptr<Obstacle> Obstacle::make_circle(const geometry::Point& center, double radius) {
+    auto Obstacle::make_circle(const geometry::Point& center, double radius) -> std::unique_ptr<Obstacle> {
         return std::make_unique<CircleObstacle>(center, radius);
     }
-
-    Obstacle::~Obstacle() {}
 
 }

--- a/path-planning/src/obstacle_circle.cpp
+++ b/path-planning/src/obstacle_circle.cpp
@@ -7,7 +7,7 @@ namespace pathplanning::map {
     CircleObstacle::CircleObstacle(const geometry::Point& center, double radius):
         center(center), radius(radius) {}
 
-    SurfaceRelationship CircleObstacle::get_relation_with_zone(const geometry::StraightRectangle& zone) const {
+    auto CircleObstacle::get_relation_with_zone(const geometry::StraightRectangle& zone) const -> SurfaceRelationship {
         if (contains(zone)) {
             return SurfaceRelationship::CONTAINS;
         } else if (contained(zone)) {
@@ -18,7 +18,7 @@ namespace pathplanning::map {
         return SurfaceRelationship::DISJOINT;
     }
 
-    bool CircleObstacle::contains(const geometry::StraightRectangle& zone) const {
+    auto CircleObstacle::contains(const geometry::StraightRectangle& zone) const -> bool {
         if (contains_point(zone.get_bottom_left_corner()) && 
                 contains_point(zone.get_top_left_corner()) &&
                 contains_point(zone.get_bottom_right_corner()) &&
@@ -28,7 +28,7 @@ namespace pathplanning::map {
         return false;
     }
 
-    bool CircleObstacle::contained(const geometry::StraightRectangle& rectangle) const {
+    auto CircleObstacle::contained(const geometry::StraightRectangle& rectangle) const -> bool {
         double left_most_x = center.get_x() - radius;
         double right_most_x = center.get_x() + radius;
         double top_most_y = center.get_y() + radius;
@@ -42,7 +42,7 @@ namespace pathplanning::map {
     }
 
     // Implemented based on https://stackoverflow.com/questions/401847/circle-rectangle-collision-detection-intersection
-    bool CircleObstacle::overlap(const geometry::StraightRectangle& zone) const {
+    auto CircleObstacle::overlap(const geometry::StraightRectangle& zone) const -> bool {
         double distance_x = std::abs(center.get_x() - zone.get_center().get_x());
         double distance_y = std::abs(center.get_y() - zone.get_center().get_y());
 
@@ -67,7 +67,7 @@ namespace pathplanning::map {
         return false;
     }
 
-    bool CircleObstacle::contains_point(const geometry::Point& point) const {
+    auto CircleObstacle::contains_point(const geometry::Point& point) const -> bool {
         if (std::pow(center.get_x() - point.get_x(), 2) + std::pow(center.get_y() - point.get_y(), 2) > std::pow(radius, 2)) {
             return false;
         }

--- a/path-planning/src/obstacle_circle.hpp
+++ b/path-planning/src/obstacle_circle.hpp
@@ -9,14 +9,14 @@ namespace pathplanning::map {
     public:
         CircleObstacle(const geometry::Point& center, double radius);
 
-        SurfaceRelationship get_relation_with_zone(const geometry::StraightRectangle& rectangle) const override;
+        auto get_relation_with_zone(const geometry::StraightRectangle& rectangle) const -> SurfaceRelationship override;
 
     private:
-        bool contains(const geometry::StraightRectangle& rectangle) const;
-        bool contained(const geometry::StraightRectangle& rectangle) const;
-        bool overlap(const geometry::StraightRectangle& rectangle) const;
+        auto contains(const geometry::StraightRectangle& rectangle) const -> bool;
+        auto contained(const geometry::StraightRectangle& rectangle) const -> bool;
+        auto overlap(const geometry::StraightRectangle& rectangle) const -> bool;
 
-        bool contains_point(const geometry::Point& point) const;
+        auto contains_point(const geometry::Point& point) const -> bool;
 
         const geometry::Point center;
         double radius;

--- a/path-planning/src/obstacle_rectangle.cpp
+++ b/path-planning/src/obstacle_rectangle.cpp
@@ -6,7 +6,7 @@ namespace pathplanning::map {
     RectangleObstacle::RectangleObstacle(const geometry::Point& corner, const geometry::Point& opposite_corner):
         geometry::StraightRectangle(corner, opposite_corner) {}
 
-    SurfaceRelationship RectangleObstacle::get_relation_with_zone(const geometry::StraightRectangle& rectangle) const {
+    auto RectangleObstacle::get_relation_with_zone(const geometry::StraightRectangle& rectangle) const -> SurfaceRelationship {
         if (contains(rectangle)) {
             return SurfaceRelationship::CONTAINS;
         }  else if (contained(rectangle)) {
@@ -17,7 +17,7 @@ namespace pathplanning::map {
         return SurfaceRelationship::DISJOINT;
     }
 
-    bool RectangleObstacle::contains(const geometry::StraightRectangle& rectangle) const {
+    auto RectangleObstacle::contains(const geometry::StraightRectangle& rectangle) const -> bool {
         if (get_left_line() < rectangle.get_left_line() && get_right_line() > rectangle.get_right_line() &&
                 get_bottom_line() < rectangle.get_bottom_line() && get_top_line() > rectangle.get_top_line()) {
             return true;
@@ -25,7 +25,7 @@ namespace pathplanning::map {
         return false;
     }
 
-    bool RectangleObstacle::contained(const geometry::StraightRectangle& rectangle) const {
+    auto RectangleObstacle::contained(const geometry::StraightRectangle& rectangle) const -> bool {
         if (rectangle.get_left_line() < get_left_line() && rectangle.get_right_line() > get_right_line() && 
             rectangle.get_bottom_line() < get_bottom_line() && rectangle.get_top_line() > get_top_line()) {
                 return true;
@@ -33,7 +33,7 @@ namespace pathplanning::map {
         return false;
     }
 
-    bool RectangleObstacle::overlap(const geometry::StraightRectangle& rectangle) const {
+    auto RectangleObstacle::overlap(const geometry::StraightRectangle& rectangle) const -> bool {
         if (get_right_line() <= rectangle.get_left_line() || get_left_line() >= rectangle.get_right_line()) {
             // If x coordinates don't cross, it's impossible to have an overlap
             return false;

--- a/path-planning/src/obstacle_rectangle.hpp
+++ b/path-planning/src/obstacle_rectangle.hpp
@@ -10,12 +10,12 @@ namespace pathplanning::map {
     public:
         RectangleObstacle(const geometry::Point& corner, const geometry::Point& opposite_corner);
 
-        SurfaceRelationship get_relation_with_zone(const geometry::StraightRectangle& rectangle) const override;
+        auto get_relation_with_zone(const geometry::StraightRectangle& rectangle) const -> SurfaceRelationship override;
 
     private:
-        bool contains(const geometry::StraightRectangle& rectangle) const;
-        bool contained(const geometry::StraightRectangle& rectangle) const;
-        bool overlap(const geometry::StraightRectangle& rectangle) const;
+        auto contains(const geometry::StraightRectangle& rectangle) const -> bool;
+        auto contained(const geometry::StraightRectangle& rectangle) const -> bool;
+        auto overlap(const geometry::StraightRectangle& rectangle) const -> bool;
     };
 
 }

--- a/path-planning/src/point.cpp
+++ b/path-planning/src/point.cpp
@@ -8,19 +8,19 @@ namespace pathplanning::geometry {
     Point::Point(double x, double y):
         x(x), y(y) {}
 
-    bool Point::operator==(const Point& other) const {
+    auto Point::operator==(const Point& other) const -> bool {
         return math::almost_equal(x, other.x) && math::almost_equal(y, other.y);
     }
 
-    double Point::euclidian_distance(const Point& other) const {
+    auto Point::euclidian_distance(const Point& other) const -> double {
         return std::sqrt(std::pow(x - other.x, 2) + std::pow(y - other.y, 2));
     }
 
-    double Point::get_x() const {
+    auto Point::get_x() const -> double {
         return x;
     }
 
-    double Point::get_y() const {
+    auto Point::get_y() const -> double {
         return y;
     }
 

--- a/path-planning/src/quadtree.hpp
+++ b/path-planning/src/quadtree.hpp
@@ -6,6 +6,7 @@
 
 #include <path-planning/point.hpp>
 #include <path-planning/shape.hpp>
+#include <utility>
 
 namespace pathplanning::quadtree {
 
@@ -31,46 +32,46 @@ namespace pathplanning::quadtree {
             splitting_point(splitting_point), top_left_value(value), top_right_value(value),
             bottom_left_value(value), bottom_right_value(value) {}
 
-        SplittingNodeInfo& with_top_left_value(const T& value) {
+        auto with_top_left_value(const T& value) -> SplittingNodeInfo& {
             top_left_value = value;
             return *this;
         }
 
-        SplittingNodeInfo& with_top_right_value(const T& value) {
+        auto with_top_right_value(const T& value) -> SplittingNodeInfo& {
             top_right_value = value;
             return *this;
         }
 
-        SplittingNodeInfo& with_bottom_left_value(const T& value) {
+        auto with_bottom_left_value(const T& value) -> SplittingNodeInfo& {
             bottom_left_value = value;
             return *this;
         }
 
-        SplittingNodeInfo& with_bottom_right_value(const T& value) {
+        auto with_bottom_right_value(const T& value) -> SplittingNodeInfo& {
             bottom_right_value = value;
             return *this;
         }
 
-        const geometry::Point& get_splitting_point() const {
+        auto get_splitting_point() const -> const geometry::Point& {
             return splitting_point;
         }
 
-        const T& get_top_left_value() const {
+        auto get_top_left_value() const -> const T& {
             validate();
             return *top_left_value;
         }
 
-        const T& get_top_right_value() const {
+        auto get_top_right_value() const -> const T& {
             validate();
             return *top_right_value;
         }
 
-        const T& get_bottom_left_value() const {
+        auto get_bottom_left_value() const -> const T& {
             validate();
             return *bottom_left_value;
         }
 
-        const T& get_bottom_right_value() const {
+        auto get_bottom_right_value() const -> const T& {
             validate();
             return *bottom_right_value;
         }
@@ -100,21 +101,21 @@ namespace pathplanning::quadtree {
     template<class T>
     class Node {
     public:
-        NodeType get_type() const {
+        auto get_type() const -> NodeType {
             if (value.has_value()) {
                 return NodeType::LEAF;
             }
             return NodeType::BRANCH;
         }
 
-        std::shared_ptr<Branches<T>> get_branches() const {
+        auto get_branches() const -> std::shared_ptr<Branches<T>> {
             if (get_type() != NodeType::BRANCH) {
                 throw std::logic_error("Can not get tree branches when node is not a branch");
             }
             return branches;
         }
 
-        const T& get_leaf_value() const {
+        auto get_leaf_value() const -> const T& {
             if (get_type() != NodeType::LEAF) {
                 throw std::logic_error("Can not get leaf value when node is not a leaf");
             }
@@ -128,7 +129,7 @@ namespace pathplanning::quadtree {
             this->value = value;
         }
 
-        const BoundingBox& get_bounding_box() const {
+        auto get_bounding_box() const -> const BoundingBox& {
             return bounding_box;
         }
 
@@ -155,7 +156,7 @@ namespace pathplanning::quadtree {
             bounding_box(bounding_box), value(value), branches(nullptr) {}
 
     private:
-        std::shared_ptr<Branches<T>> build_branches_for_split(const SplittingNodeInfo<T>& info) const {
+        auto build_branches_for_split(const SplittingNodeInfo<T>& info) const -> std::shared_ptr<Branches<T>> {
             geometry::Point split_point = info.get_splitting_point();
             Node<T> top_left(BoundingBox(split_point, bounding_box.get_top_left_corner()), info.get_top_left_value());
             Node<T> top_right(BoundingBox(split_point, bounding_box.get_top_right_corner()), info.get_top_right_value());
@@ -183,47 +184,47 @@ namespace pathplanning::quadtree {
     template<class T>
     class Branches {
     public:
-        const Node<T>& get_top_right_node() const {
+        auto get_top_right_node() const -> const Node<T>& {
             return top_right;
         }
 
-        Node<T>& get_top_right_node() {
+        auto get_top_right_node() -> Node<T>& {
             return top_right;
         }
 
-        const Node<T>& get_top_left_node() const {
+        auto get_top_left_node() const -> const Node<T>& {
             return top_left;
         }
 
-        Node<T>& get_top_left_node() {
+        auto get_top_left_node() -> Node<T>& {
             return top_left;
         }
 
-        const Node<T>& get_bottom_left_node() const {
+        auto get_bottom_left_node() const -> const Node<T>& {
             return bottom_left;
         }
 
-        Node<T>& get_bottom_left_node() {
+        auto get_bottom_left_node() -> Node<T>& {
             return bottom_left;
         }
 
-        const Node<T>& get_bottom_right_node() const {
+        auto get_bottom_right_node() const -> const Node<T>& {
             return bottom_right;
         }
 
-        Node<T>& get_bottom_right_node() {
+        auto get_bottom_right_node() -> Node<T>& {
             return bottom_right;
         }
 
-        geometry::Point get_splitting_point() const {
+        auto get_splitting_point() const -> geometry::Point {
             return top_left.get_bounding_box().get_bottom_right_corner();
         }
 
     private:
-        Branches(const Node<T>& top_right, const Node<T>& top_left,
-            const Node<T>& bottom_left, const Node<T>& bottom_right):
-                top_right(top_right), top_left(top_left), bottom_left(bottom_left), 
-                bottom_right(bottom_right) {}
+        Branches(Node<T>  top_right, Node<T>  top_left,
+            Node<T>  bottom_left, Node<T>  bottom_right):
+                top_right(std::move(top_right)), top_left(std::move(top_left)), bottom_left(std::move(bottom_left)), 
+                bottom_right(std::move(bottom_right)) {}
 
         Node<T> top_left;
         Node<T> top_right;

--- a/path-planning/src/rectangle.cpp
+++ b/path-planning/src/rectangle.cpp
@@ -19,53 +19,53 @@ namespace pathplanning::geometry {
         }
     }
 
-    double StraightRectangle::get_left_line() const {
+    auto StraightRectangle::get_left_line() const -> double {
         return bottom_left_corner.get_x();
     }
 
-    double StraightRectangle::get_right_line() const {
+    auto StraightRectangle::get_right_line() const -> double {
         return top_right_corner.get_x();
     }
 
-    double StraightRectangle::get_bottom_line() const {
+    auto StraightRectangle::get_bottom_line() const -> double {
         return bottom_left_corner.get_y();
     }
 
-    double StraightRectangle::get_top_line() const {
+    auto StraightRectangle::get_top_line() const -> double {
         return top_right_corner.get_y();
     }
 
-    Point StraightRectangle::get_top_left_corner() const {
+    auto StraightRectangle::get_top_left_corner() const -> Point {
         return Point(get_left_line(), get_top_line());
     }
 
-    Point StraightRectangle::get_top_right_corner() const {
+    auto StraightRectangle::get_top_right_corner() const -> Point {
         return top_right_corner;
     }
 
-    Point StraightRectangle::get_bottom_left_corner() const {
+    auto StraightRectangle::get_bottom_left_corner() const -> Point {
         return bottom_left_corner;
     }
 
-    Point StraightRectangle::get_bottom_right_corner() const {
+    auto StraightRectangle::get_bottom_right_corner() const -> Point {
         return Point(get_right_line(), get_bottom_line());
     }
 
-    double StraightRectangle::get_width() const {
+    auto StraightRectangle::get_width() const -> double {
         return std::abs(get_right_line() - get_left_line());
     }
 
-    double StraightRectangle::get_height() const {
+    auto StraightRectangle::get_height() const -> double {
         return std::abs(get_top_line() - get_bottom_line());
     }
 
-    Point StraightRectangle::get_center() const {
+    auto StraightRectangle::get_center() const -> Point {
         double x = (get_right_line() + get_left_line())/2;
         double y = (get_top_line() + get_bottom_line())/2;
         return Point(x, y);
     }
 
-    double StraightRectangle::get_area() const {
+    auto StraightRectangle::get_area() const -> double {
         return get_width() * get_height();
     }
 }

--- a/path-planning/tests/CMakeLists.txt
+++ b/path-planning/tests/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Disable clang-tidy for test
+set(CMAKE_CXX_CLANG_TIDY "")
+
 add_executable("path-planning-test"
     test_obstacle_circle.cpp
     test_obstacle_rectangle.cpp

--- a/robotlib/include/robotlib/proximity_handler.hpp
+++ b/robotlib/include/robotlib/proximity_handler.hpp
@@ -9,7 +9,7 @@ namespace robotlib::proximity_handler {
     class ProximityHandler {
     public: 
         ProximityHandler(const UltraSonicSensor& us_sensor, const double min_distance);
-        bool is_too_close() const;
+        auto is_too_close() const -> bool;
 
     private: 
         const double min_distance;

--- a/robotlib/src/proximity_handler.cpp
+++ b/robotlib/src/proximity_handler.cpp
@@ -5,7 +5,7 @@ namespace robotlib::proximity_handler {
     ProximityHandler::ProximityHandler(const UltraSonicSensor& us_sensor, const double min_distance):
         us_sensor(us_sensor), min_distance(min_distance) {}
 
-    bool ProximityHandler::is_too_close() const {
+    auto ProximityHandler::is_too_close() const -> bool {
         const double distance = us_sensor.get_distance();
 
         if (distance > min_distance) {

--- a/robotlib/tests/CMakeLists.txt
+++ b/robotlib/tests/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Disable clang-tidy for test
+set(CMAKE_CXX_CLANG_TIDY "")
+
 add_executable("robotlib-test"
     test-proximity-detection.cpp
     main.cpp)

--- a/visualization/bin/CMakeLists.txt
+++ b/visualization/bin/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Disable clang-tidy for bin
+set(CMAKE_CXX_CLANG_TIDY "")
+
 add_executable("svg-example"
     svg-example.cpp)
 

--- a/visualization/bin/svg-example.cpp
+++ b/visualization/bin/svg-example.cpp
@@ -1,7 +1,7 @@
 #include <visualization/rectangle.hpp>
 #include <visualization/line.hpp>
 #include <visualization/circle.hpp>
-#include <visualization/svg.hpp>
+#include <visualization/renderer.hpp>
 
 #include <fstream>
 
@@ -9,22 +9,22 @@ using namespace visualization;
 
 int main() {
     //Temporary
-    render::SVGRenderer svg_content = render::SVGRenderer("test", 100, 100);
+    std::unique_ptr<render::Renderer> svg_content = render::Renderer::make_svg_renderer("test", 100, 100);
 
     geometry::Point start = geometry::Point(80, 80);
     geometry::Point end = geometry::Point(90, 90);
     geometry::Line line = geometry::Line(start, end);
-    svg_content.add_line(line);
+    svg_content->add_line(line);
 
     geometry::Point center1 = geometry::Point(10, 10);
     geometry::Rectangle renctangle1 = geometry::Rectangle(20, 20, center1);
-    svg_content.add_rectangle(renctangle1);
+    svg_content->add_rectangle(renctangle1);
 
     geometry::Point center2 = geometry::Point(50,50);
     geometry::Circle circle1 = geometry::Circle(center2, 5);
-    svg_content.add_circle(circle1);
+    svg_content->add_circle(circle1);
 
     std::ofstream output("test.svg");
-    output << svg_content.render();
+    output << svg_content->render();
     output.close();
 }

--- a/visualization/include/visualization/circle.hpp
+++ b/visualization/include/visualization/circle.hpp
@@ -8,8 +8,8 @@ namespace visualization::geometry {
     public:
         Circle(const Point& center, double radius);
 
-        double get_radius() const;
-        const Point& get_center() const;
+        auto get_radius() const -> double;
+        auto get_center() const -> const Point&;
     private:
         Point center;
         double radius;

--- a/visualization/include/visualization/line.hpp
+++ b/visualization/include/visualization/line.hpp
@@ -8,8 +8,8 @@ namespace visualization::geometry {
     public:
         Line(const Point& start, const Point& end);
 
-        const Point& get_start() const;
-        const Point& get_end() const;
+        auto get_start() const -> const Point&;
+        auto get_end() const -> const Point&;
     private:
         const Point start;
         const Point end;

--- a/visualization/include/visualization/point.hpp
+++ b/visualization/include/visualization/point.hpp
@@ -6,8 +6,8 @@ namespace visualization::geometry {
     public:
         Point(double x, double y);
 
-        double get_x() const;
-        double get_y() const;
+        auto get_x() const -> double;
+        auto get_y() const -> double;
     private:
         double x;
         double y;

--- a/visualization/include/visualization/rectangle.hpp
+++ b/visualization/include/visualization/rectangle.hpp
@@ -8,9 +8,9 @@ namespace visualization::geometry {
     public:
         Rectangle(double width, double height, const Point& center);
 
-        double get_width() const;
-        double get_height() const;
-        const Point& get_center() const;
+        auto get_width() const -> double;
+        auto get_height() const -> double;
+        auto get_center() const -> const Point&;
     private:
         double width;
         double height;

--- a/visualization/include/visualization/render.hpp
+++ b/visualization/include/visualization/render.hpp
@@ -16,7 +16,7 @@ namespace visualization::render {
         virtual void add_line(const geometry::Line& line) = 0;
         virtual void add_rectangle(const geometry::Rectangle& rectangle) = 0;
         virtual void add_circle(const geometry::Circle& circle) = 0;
-        virtual std::string render() const = 0;
+        virtual auto render() const -> std::string = 0;
     };
     
 }

--- a/visualization/include/visualization/renderer.hpp
+++ b/visualization/include/visualization/renderer.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <string>
 
 #include "line.hpp"
@@ -10,9 +11,10 @@ namespace visualization::render {
 
     class Renderer {
     public:
+        static auto make_svg_renderer(const std::string& name, double width, double height) -> std::unique_ptr<Renderer>;
+
         virtual ~Renderer() = default;
 
-    private:
         virtual void add_line(const geometry::Line& line) = 0;
         virtual void add_rectangle(const geometry::Rectangle& rectangle) = 0;
         virtual void add_circle(const geometry::Circle& circle) = 0;

--- a/visualization/include/visualization/svg.hpp
+++ b/visualization/include/visualization/svg.hpp
@@ -10,13 +10,13 @@ namespace visualization::render {
 
     class SVGRenderer: public Renderer {
     public:
-        SVGRenderer(const std::string name, double width, double height);
+        SVGRenderer(const std::string& name, double width, double height);
 
         void add_line(const geometry::Line& line) override;
         void add_rectangle(const geometry::Rectangle& rectangle) override;
         void add_circle(const geometry::Circle& circle) override;
 
-        std::string render() const override;
+        auto render() const -> std::string override;
     private:
         double width;
         double height;

--- a/visualization/include/visualization/xml_node.hpp
+++ b/visualization/include/visualization/xml_node.hpp
@@ -10,9 +10,9 @@ namespace visualization::render {
     public:
         class Builder;
 
-        const std::string to_string() const;
+        auto to_string() const -> const std::string;
     private: 
-        XMLNode(const std::string tag, const std::vector<std::pair<std::string, std::string>> attributes);
+        XMLNode(const std::string& tag, const std::vector<std::pair<std::string, std::string>>& attributes);
 
         std::string tag;
         std::vector<std::pair<std::string, std::string>> attributes;
@@ -20,11 +20,11 @@ namespace visualization::render {
 
     class XMLNode::Builder {
     public: 
-        Builder(const std::string tag);
+        Builder(const std::string& tag);
 
-        Builder& with_attribute(const std::string name, const std::string value);
+        auto with_attribute(const std::string& name, const std::string& value) -> Builder&;
         
-        XMLNode build() const;
+        auto build() const -> XMLNode;
     private: 
         std::string tag;
         std::vector<std::pair<std::string, std::string>> attributes;

--- a/visualization/src/CMakeLists.txt
+++ b/visualization/src/CMakeLists.txt
@@ -4,7 +4,8 @@ add_library("visualization"
     circle.cpp
     line.cpp
     xml_node.cpp
-    svg.cpp
+    renderer.cpp
+    svg_renderer.cpp
 )
 
 target_include_directories("visualization" 

--- a/visualization/src/circle.cpp
+++ b/visualization/src/circle.cpp
@@ -6,11 +6,11 @@ namespace visualization::geometry {
         center(center), radius(radius) {
     }
 
-    double Circle::get_radius() const {
+    auto Circle::get_radius() const -> double {
         return radius;
     }
     
-    const Point& Circle::get_center() const {
+    auto Circle::get_center() const -> const Point& {
         return center;
     }
 }

--- a/visualization/src/line.cpp
+++ b/visualization/src/line.cpp
@@ -6,11 +6,11 @@ namespace visualization::geometry {
         start(start), end(end) {
     }
 
-    const Point& Line::get_start() const {
+    auto Line::get_start() const -> const Point& {
         return start;
     }
     
-    const Point& Line::get_end() const {
+    auto Line::get_end() const -> const Point& {
         return end;
     }
 }

--- a/visualization/src/point.cpp
+++ b/visualization/src/point.cpp
@@ -5,11 +5,11 @@ namespace visualization::geometry {
     Point::Point(double x, double y):
         x(x), y(y) {}
 
-    double Point::get_x() const {
+    auto Point::get_x() const -> double {
         return x;
     }
 
-    double Point::get_y() const {
+    auto Point::get_y() const -> double {
         return y;
     }
 }

--- a/visualization/src/rectangle.cpp
+++ b/visualization/src/rectangle.cpp
@@ -6,15 +6,15 @@ namespace visualization::geometry {
         width(width), height(height), center(center) {
     }
 
-    double Rectangle::get_width() const {
+    auto Rectangle::get_width() const -> double {
         return width;
     }
 
-    double Rectangle::get_height() const {
+    auto Rectangle::get_height() const -> double {
         return height;
     }
 
-    const Point& Rectangle::get_center() const {
+    auto Rectangle::get_center() const -> const Point& {
         return center;
     }
 }

--- a/visualization/src/renderer.cpp
+++ b/visualization/src/renderer.cpp
@@ -1,0 +1,9 @@
+#include <visualization/renderer.hpp>
+
+#include "svg_renderer.hpp"
+
+namespace visualization::render {
+    auto Renderer::make_svg_renderer(const std::string& name, double width, double height) -> std::unique_ptr<Renderer> {
+        return std::make_unique<SVGRenderer>(name, width, height);
+    }
+}

--- a/visualization/src/svg.cpp
+++ b/visualization/src/svg.cpp
@@ -4,7 +4,7 @@
 
 namespace visualization::render {
 
-    SVGRenderer::SVGRenderer(const std::string name, double width, double height):
+    SVGRenderer::SVGRenderer(const std::string& name, double width, double height):
         name(name), width(width), height(height) {}
 
     void SVGRenderer::add_line(const geometry::Line& line) {
@@ -40,7 +40,7 @@ namespace visualization::render {
         nodes.push_back(node);
     }
     
-    std::string SVGRenderer::render() const {
+    auto SVGRenderer::render() const -> std::string {
         std::stringstream svg_built;
 
         svg_built << "<svg width=\"" << width << "\" height=\"" << height << "\">\n";

--- a/visualization/src/svg_renderer.cpp
+++ b/visualization/src/svg_renderer.cpp
@@ -1,11 +1,12 @@
-#include <visualization/svg.hpp>
+#include "svg_renderer.hpp"
 
 #include <sstream>
+#include <utility>
 
 namespace visualization::render {
 
-    SVGRenderer::SVGRenderer(const std::string& name, double width, double height):
-        name(name), width(width), height(height) {}
+    SVGRenderer::SVGRenderer(std::string name, double width, double height):
+        name(std::move(name)), width(width), height(height) {}
 
     void SVGRenderer::add_line(const geometry::Line& line) {
         XMLNode node = XMLNode::Builder("line")

--- a/visualization/src/svg_renderer.hpp
+++ b/visualization/src/svg_renderer.hpp
@@ -3,14 +3,14 @@
 #include <string>
 #include <vector>
 
-#include "render.hpp"
+#include <visualization/renderer.hpp>
 #include "xml_node.hpp"
 
 namespace visualization::render {
 
     class SVGRenderer: public Renderer {
     public:
-        SVGRenderer(const std::string& name, double width, double height);
+        SVGRenderer(std::string name, double width, double height);
 
         void add_line(const geometry::Line& line) override;
         void add_rectangle(const geometry::Rectangle& rectangle) override;

--- a/visualization/src/xml_node.cpp
+++ b/visualization/src/xml_node.cpp
@@ -1,14 +1,15 @@
-#include <visualization/xml_node.hpp>
+#include "xml_node.hpp"
 
 #include <sstream>
+#include <utility>
 
 namespace visualization::render {
 
-    XMLNode::XMLNode(const std::string& tag, const std::vector<std::pair<std::string, std::string>>& attributes):
+    XMLNode::XMLNode(std::string&& tag, std::vector<std::pair<std::string, std::string>>&& attributes):
         tag(tag), attributes(attributes) {}
     
-    XMLNode::Builder::Builder(const std::string& tag): 
-        tag(tag) {}
+    XMLNode::Builder::Builder(std::string tag):
+        tag(std::move(tag)) {}
 
     auto XMLNode::Builder::with_attribute(const std::string& name, const std::string& value) -> XMLNode::Builder& {
         std::pair <std::string, std::string> attribute(name, value);
@@ -16,8 +17,8 @@ namespace visualization::render {
         return *this;
     }
 
-    auto XMLNode::Builder::build() const -> XMLNode {
-        return XMLNode(tag, attributes);
+    auto XMLNode::Builder::build() -> XMLNode {
+        return XMLNode(std::move(tag), std::move(attributes));
     }
 
     auto XMLNode::to_string() const -> const std::string {

--- a/visualization/src/xml_node.cpp
+++ b/visualization/src/xml_node.cpp
@@ -4,28 +4,28 @@
 
 namespace visualization::render {
 
-    XMLNode::XMLNode(const std::string tag, const std::vector<std::pair<std::string, std::string>> attributes):
+    XMLNode::XMLNode(const std::string& tag, const std::vector<std::pair<std::string, std::string>>& attributes):
         tag(tag), attributes(attributes) {}
     
-    XMLNode::Builder::Builder(const std::string tag): 
+    XMLNode::Builder::Builder(const std::string& tag): 
         tag(tag) {}
 
-    XMLNode::Builder& XMLNode::Builder::with_attribute(const std::string name, const std::string value) {
+    auto XMLNode::Builder::with_attribute(const std::string& name, const std::string& value) -> XMLNode::Builder& {
         std::pair <std::string, std::string> attribute(name, value);
         attributes.push_back(attribute);
         return *this;
     }
 
-    XMLNode XMLNode::Builder::build() const {
+    auto XMLNode::Builder::build() const -> XMLNode {
         return XMLNode(tag, attributes);
     }
 
-    const std::string XMLNode::to_string() const {
+    auto XMLNode::to_string() const -> const std::string {
         std::stringstream node_builder;
 
         node_builder << "\t<" << tag;
-        for(std::vector<std::pair<std::string, std::string>>::const_iterator it = attributes.begin(); it != attributes.end(); it++){
-            node_builder << " "<< it->first << "=\"" << it->second <<"\"";
+        for(const auto & attribute : attributes){
+            node_builder << " "<< attribute.first << "=\"" << attribute.second <<"\"";
         }
         node_builder << "/>\n";
 

--- a/visualization/src/xml_node.hpp
+++ b/visualization/src/xml_node.hpp
@@ -12,7 +12,7 @@ namespace visualization::render {
 
         auto to_string() const -> const std::string;
     private: 
-        XMLNode(const std::string& tag, const std::vector<std::pair<std::string, std::string>>& attributes);
+        XMLNode(std::string&& tag, std::vector<std::pair<std::string, std::string>>&& attributes);
 
         std::string tag;
         std::vector<std::pair<std::string, std::string>> attributes;
@@ -20,11 +20,11 @@ namespace visualization::render {
 
     class XMLNode::Builder {
     public: 
-        Builder(const std::string& tag);
+        Builder(std::string tag);
 
         auto with_attribute(const std::string& name, const std::string& value) -> Builder&;
         
-        auto build() const -> XMLNode;
+        auto build() -> XMLNode;
     private: 
         std::string tag;
         std::vector<std::pair<std::string, std::string>> attributes;

--- a/visualization/tests/CMakeLists.txt
+++ b/visualization/tests/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Disable clang-tidy for test
+set(CMAKE_CXX_CLANG_TIDY "")
+
 add_executable("visualization-test"
     main.cpp)
 


### PR DESCRIPTION
The most controversial rule I see is [modernize-use-trailing-return-type](https://clang.llvm.org/extra/clang-tidy/checks/modernize-use-trailing-return-type.html) which modifies things like this:
```cpp
int f1();
inline int f2(int arg) noexcept;
virtual float f3() const && = delete;

// transforms to:

auto f1() -> int;
inline auto f2(int arg) -> int noexcept;
virtual auto f3() const && -> float = delete;
```

Personally, I quite like the syntax but if you prefer the more standard C++98 syntax. I don't see any issues to revert this rule. 